### PR TITLE
Improved Disk Info Handling

### DIFF
--- a/core/src/utils/system_info.rs
+++ b/core/src/utils/system_info.rs
@@ -6,20 +6,40 @@ use mockall::predicate::*;
 use mockall::*;
 use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::process::Command;
 use sys_info;
+use sysinfo::{DiskExt, System, SystemExt};
 
 use super::compute_file_size;
 use crate::net::ip_manager;
 use crate::SERVER_PORT;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MyDisk {
+    type_: String,
+    device_name: String,
+    file_system: Vec<u8>,
+    mount_point: String,
+    total_space: u64,
+    available_space: u64,
+    is_removable: bool,
+}
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Drives {
+    array_of_drives: Vec<MyDisk>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemInformation {
     /// the current user name eg - drizzle
     pub system_name: String,
+    /// the disks
+    pub disk: Drives,
     /// available store
     pub available_disk: String,
-    /// used store
+    /// used space
     pub used_disk: String,
     /// the port on which the core server runs
     port: u128,
@@ -36,6 +56,9 @@ impl std::default::Default for SystemInformation {
     fn default() -> Self {
         Self {
             system_name: String::from(""),
+            disk: Drives {
+                array_of_drives: Vec::new(),
+            },
             available_disk: String::from(""),
             used_disk: String::from(""),
             remaining_time: None,
@@ -67,11 +90,6 @@ impl SystemInformation {
 
         // Get the used memory information
 
-        let disk_info = system_info.get_disk_info();
-
-        let available_disk = disk_info.free;
-        let used_disk = disk_info.total - disk_info.free;
-
         let remaining_time = match system_info.remaining_battery_time() {
             Some(mut seconds) => {
                 let remaining_hours = seconds / 3600;
@@ -86,11 +104,33 @@ impl SystemInformation {
             }
             None => None,
         };
+        let disk = match system_info.get_disk_info() {
+            Ok(drives) => drives,
+            Err(_) => Drives {
+                array_of_drives: vec![],
+            },
+        };
+
+        let available_disk: String = compute_file_size(
+            disk.array_of_drives
+                .iter()
+                .filter(|disk| disk.type_ == "HDD" || disk.type_ == "SSD")
+                .map(|disk| disk.available_space)
+                .sum::<u64>() as u128,
+        );
+        let used_disk: String = compute_file_size(
+            disk.array_of_drives
+                .iter()
+                .filter(|disk| disk.type_ == "HDD" || disk.type_ == "SSD")
+                .map(|disk| disk.total_space - disk.available_space)
+                .sum::<u64>() as u128,
+        );
 
         Self {
             system_name,
-            available_disk: compute_file_size(available_disk as u128),
-            used_disk: compute_file_size(used_disk as u128),
+            disk,
+            available_disk,
+            used_disk,
             port: port.into(),
             ip_address: ip_address.clone().unwrap(),
             server_base_url: format!("http://{}:{}", ip_address.unwrap(), port),
@@ -102,19 +142,34 @@ impl SystemInformation {
 pub struct DefaultSystemInfoGetter;
 #[automock]
 pub trait GetSystemInformation {
-    fn get_disk_info(&self) -> sys_info::DiskInfo;
+    fn get_disk_info(&self) -> Result<Drives, String>;
     fn remaining_battery_time(&self) -> Option<u64>;
 }
 
 impl GetSystemInformation for DefaultSystemInfoGetter {
-    fn get_disk_info(&self) -> sys_info::DiskInfo {
-        match sys_info::disk_info() {
-            Ok(info) => info,
-            Err(e) => {
-                println!("Failed to get disk information: {:?}", e);
-                sys_info::DiskInfo { total: 0, free: 0 }
+    fn get_disk_info(&self) -> Result<Drives, String> {
+        let mut array_of_drives = Vec::new();
+        let mut system = System::new_all();
+        let mut hashset: HashSet<String> = HashSet::new();
+        system.refresh_all();
+        for disk in system.disks() {
+            if hashset.insert(disk.name().to_string_lossy().to_string()) {
+                array_of_drives.push(MyDisk {
+                    type_: match disk.kind() {
+                        sysinfo::DiskKind::HDD => format!("HDD"),
+                        sysinfo::DiskKind::SSD => format!("SSD"),
+                        _ => format!("Removeable disk"),
+                    },
+                    device_name: disk.name().to_string_lossy().to_string(),
+                    file_system: disk.file_system().to_vec(),
+                    mount_point: disk.mount_point().to_string_lossy().to_string(),
+                    total_space: disk.total_space(),
+                    available_space: disk.available_space(),
+                    is_removable: disk.is_removable(),
+                });
             }
         }
+        Ok(Drives { array_of_drives })
     }
 
     fn remaining_battery_time(&self) -> Option<u64> {
@@ -138,18 +193,20 @@ impl GetSystemInformation for DefaultSystemInfoGetter {
 
 //impl display for system information type
 impl fmt::Display for SystemInformation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "system_name: {},
-            available_disk: {},
-            used_disk: {},
+            disk: {:?},
+            available space: {},
+            used space: {},
             port: {},
             remaining_time: {}
             ip_address {:?}
             server_base_url {:?}
             ",
             self.system_name,
+            self.disk,
             self.available_disk,
             self.used_disk,
             self.port,
@@ -168,9 +225,19 @@ mod tests {
     use super::*;
 
     fn set_disk_info(mock_item: &mut MockGetSystemInformation, total: u64, free: u64) {
-        mock_item
-            .expect_get_disk_info()
-            .returning(move || sys_info::DiskInfo { total, free });
+        mock_item.expect_get_disk_info().returning(move || {
+            Ok(Drives {
+                array_of_drives: vec![MyDisk {
+                    type_: "HDD".to_string(),
+                    device_name: "".to_string(),
+                    file_system: Vec::<u8>::new(),
+                    mount_point: "".to_string(),
+                    total_space: total,
+                    available_space: free,
+                    is_removable: false,
+                }],
+            })
+        });
     }
     fn set_remaining_battery_time(mock: &mut MockGetSystemInformation, remaining: Option<u64>) {
         mock.expect_remaining_battery_time()
@@ -186,13 +253,20 @@ mod tests {
         assert_eq!(target, result)
     }
     #[test]
+    fn mock_disk_info_is_used() {
+        let mut mock = MockGetSystemInformation::new();
+        set_disk_info(&mut mock, 1024, 128);
+        set_remaining_battery_time(&mut mock, None);
+        let result = get_system_info(mock);
+        available_disk_should_be(format!("{} B", 1024 - 128), result.used_disk);
+    }
+    #[test]
     fn mock_disk_info_is_available() {
         let mut mock = MockGetSystemInformation::new();
         set_disk_info(&mut mock, 1024, 128);
         set_remaining_battery_time(&mut mock, None);
         let result = get_system_info(mock);
         available_disk_should_be(format!("{} B", 128), result.available_disk);
-        available_disk_should_be(format!("{} B", 1024 - 128), result.used_disk);
     }
     #[test]
     fn mock_remaining_battery_time_only_seconds() {


### PR DESCRIPTION
Retrieve disk information using the sysinfo trait. Successfully tested on Windows platform.
-   Added new structures: MyDisk and Drives to represent disk
    information.
-   Added a new field disk: Drives in the SystemInformation structure to
    store disk information.
-   Modified the implementation of GetSystemInformation trait to return
    disk information as a result of system::new_all().disks().
-   Updated the impl SystemInformation block to use the new disk
    information structure.
-   Modified the calculation of available_disk and used_disk to use the
    new disk information structure and compute the sizes.
-   Updated the fmt::Display implementation of SystemInformation to
    include disk information in the output.
-   Updated the unit tests.