### PR TITLE
Add get_available_disk method

### DIFF
--- a/core/src/utils/system_info.rs
+++ b/core/src/utils/system_info.rs
@@ -138,10 +138,11 @@ impl SystemInformation {
         }
     }
     pub fn get_available_disk(&self, folder_name: &str) -> Result<u64, String> {
-        let search = self.disk.array_of_drives.iter().find(|d| {
-            d.mount_point.as_str().split_once('\\').unwrap().0
-                == folder_name.split_once('\\').unwrap().0
-        });
+        let search = self
+            .disk
+            .array_of_drives
+            .iter()
+            .find(|d| folder_name.contains(&d.mount_point));
         match search {
             Some(disk) => Ok(disk.available_space),
             None => Err(format!("There is no disk named {}", folder_name)),


### PR DESCRIPTION
This commit introduces the `get_available_disk` method to the `SystemInformation` struct. This method enables the retrieval of available disk space for a specific folder. It takes a folder name as an argument and returns the available disk space as a `Result<u64, String>`. If the disk is found, the available space is returned; otherwise, an error message is returned.

Additionally, several tests are included to ensure the proper functionality of the code.