### PR TITLE
Add functions for Windows hotspot management

### DIFF
--- a/core/src/net/windows_hotspot.rs
+++ b/core/src/net/windows_hotspot.rs
@@ -8,7 +8,7 @@ fn command_output_to_string(output: &Vec<u8>) -> String {
 }
 /// Create hotspot on windows
 #[allow(dead_code)]
-pub fn create_ap() {
+pub fn create_ap(ssid: &str, key: &str) {
     // Check if the device support the hotspot feature
     match is_support_hotspot() {
         Ok(false) => {
@@ -21,12 +21,8 @@ pub fn create_ap() {
         }
         Ok(true) => println!("Hotspot is supported"),
     };
-    // Set up the hotspot name and password
-    let hotspot_name = "MyHotspot";
-    let hotspot_password = "MyPassword123";
-
     // Create a new hotspot
-    match create_hotspot(hotspot_name, hotspot_password) {
+    match create_hotspot(ssid, key) {
         Ok(_) => println!("Created a new hotspot"),
         Err(e) => {
             println!("{}", e);

--- a/core/src/net/windows_hotspot.rs
+++ b/core/src/net/windows_hotspot.rs
@@ -1,3 +1,5 @@
+use mockall::predicate::*;
+use mockall::*;
 use std::process::Command;
 fn command_output_to_string(output: &Vec<u8>) -> String {
     let _output = std::str::from_utf8(&output);
@@ -9,8 +11,12 @@ fn command_output_to_string(output: &Vec<u8>) -> String {
 /// Create hotspot on windows
 #[allow(dead_code)]
 pub fn create_ap(ssid: &str, key: &str) {
+    let hotspotcommand = DefaultHotSpotCommand;
+    create_ap_with_hotspotcommand(hotspotcommand, ssid, key);
+}
+fn create_ap_with_hotspotcommand<T: HotSpotCommand>(hotspotcommand: T, ssid: &str, key: &str) {
     // Check if the device support the hotspot feature
-    match is_support_hotspot() {
+    match hotspotcommand.is_support_hotspot() {
         Ok(false) => {
             println!("Hotspot is not supported");
             return;
@@ -22,7 +28,7 @@ pub fn create_ap(ssid: &str, key: &str) {
         Ok(true) => println!("Hotspot is supported"),
     };
     // Create a new hotspot
-    match create_hotspot(ssid, key) {
+    match hotspotcommand.create_hotspot(ssid, key) {
         Ok(_) => println!("Created a new hotspot"),
         Err(e) => {
             println!("{}", e);
@@ -31,7 +37,7 @@ pub fn create_ap(ssid: &str, key: &str) {
     };
 
     // Start the hotspot
-    match start_hotspot() {
+    match hotspotcommand.start_hotspot() {
         Ok(_) => println!("Started a new hotspot"),
         Err(e) => {
             println!("{}", e);
@@ -40,86 +46,220 @@ pub fn create_ap(ssid: &str, key: &str) {
     };
 }
 
+/// Turnoff the hotspot
 #[warn(dead_code)]
 pub fn turn_off_hotspot() {
-    match stop_hotspot() {
+    let hotspotcommand = DefaultHotSpotCommand;
+    turn_off_hotspot_with_hotspotcommand(hotspotcommand);
+}
+fn turn_off_hotspot_with_hotspotcommand<T: HotSpotCommand>(hotspotcommand: T) {
+    match hotspotcommand.stop_hotspot() {
         Ok(_) => println!("Stop the hotspot successfully"),
         Err(e) => println!("{}", e),
     }
 }
 
-fn is_support_hotspot() -> Result<bool, String> {
-    match Command::new("netsh")
-        .args(["wlan", "show", "drivers"])
-        .output()
-    {
-        Ok(output) => {
-            if command_output_to_string(&output.stdout)
-                .as_str()
-                .contains("Hosted network supported  : Yes")
-            {
-                Ok(true)
-            } else {
-                Ok(false)
+struct DefaultHotSpotCommand;
+#[automock]
+pub trait HotSpotCommand {
+    fn is_support_hotspot(&self) -> Result<bool, String>;
+    fn create_hotspot(&self, ssid: &str, key: &str) -> Result<(), String>;
+    fn start_hotspot(&self) -> Result<(), String>;
+    fn stop_hotspot(&self) -> Result<(), String>;
+}
+
+impl HotSpotCommand for DefaultHotSpotCommand {
+    fn is_support_hotspot(&self) -> Result<bool, String> {
+        match Command::new("netsh")
+            .args(["wlan", "show", "drivers"])
+            .output()
+        {
+            Ok(output) => {
+                if command_output_to_string(&output.stdout)
+                    .as_str()
+                    .contains("Hosted network supported  : Yes")
+                {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
             }
+            Err(_) => Err(format!("Failed to get the wlan drivers information")),
         }
-        Err(_) => Err(format!("Failed to get the wlan drivers information")),
+    }
+
+    fn create_hotspot(&self, ssid: &str, key: &str) -> Result<(), String> {
+        match Command::new("netsh")
+            .args([
+                "wlan",
+                "set",
+                "hostednetwork",
+                &("ssid=".to_owned() + ssid),
+                &("key=".to_owned() + key),
+            ])
+            .output()
+        {
+            Ok(output) => {
+                if let true = output.status.success() {
+                    return Ok(());
+                } else {
+                    return Err(format!(
+                        "Failed to create hotspot: {}",
+                        command_output_to_string(&output.stderr)
+                    ));
+                }
+            }
+            Err(_) => return Err(format!("Failed to execute create hotspot through netsh.")),
+        }
+    }
+
+    fn start_hotspot(&self) -> Result<(), String> {
+        match Command::new("netsh")
+            .args(["wlan", "start", "hostednetwork"])
+            .output()
+        {
+            Ok(output) => {
+                if command_output_to_string(&output.stdout).contains("The hosted network started.")
+                {
+                    return Ok(());
+                } else {
+                    return Err(format!("Failed to start the hosted network"));
+                }
+            }
+            Err(_) => return Err(format!("Failed to start the hosted network through netsh")),
+        }
+    }
+
+    fn stop_hotspot(&self) -> Result<(), String> {
+        match Command::new("netsh")
+            .args(["wlan", "stop", "hostednetwork"])
+            .output()
+        {
+            Ok(output) => {
+                if command_output_to_string(&output.stdout).contains("The hosted network stoped.") {
+                    return Ok(());
+                } else {
+                    return Err(format!("Failed to stop the hosted network"));
+                }
+            }
+            Err(_) => return Err(format!("Failed to stop the hosted network through netsh")),
+        }
     }
 }
 
-fn create_hotspot(ssid: &str, key: &str) -> Result<(), String> {
-    match Command::new("netsh")
-        .args([
-            "wlan",
-            "set",
-            "hostednetwork",
-            &("ssid=".to_owned() + ssid),
-            &("key=".to_owned() + key),
-        ])
-        .output()
-    {
-        Ok(output) => {
-            if let true = output.status.success() {
-                return Ok(());
-            } else {
-                return Err(format!(
-                    "Failed to create hotspot: {}",
-                    command_output_to_string(&output.stderr)
-                ));
-            }
-        }
-        Err(_) => return Err(format!("Failed to execute create hotspot through netsh.")),
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::Sequence;
 
-fn start_hotspot() -> Result<(), String> {
-    match Command::new("netsh")
-        .args(["wlan", "start", "hostednetwork"])
-        .output()
-    {
-        Ok(output) => {
-            if command_output_to_string(&output.stdout).contains("The hosted network started.") {
-                return Ok(());
-            } else {
-                return Err(format!("Failed to start the hosted network"));
-            }
-        }
-        Err(_) => return Err(format!("Failed to start the hosted network through netsh")),
-    }
-}
+    #[test]
+    fn test_create_ap_when_success() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
 
-fn stop_hotspot() -> Result<(), String> {
-    match Command::new("netsh")
-        .args(["wlan", "stop", "hostednetwork"])
-        .output()
-    {
-        Ok(output) => {
-            if command_output_to_string(&output.stdout).contains("The hosted network stoped.") {
-                return Ok(());
-            } else {
-                return Err(format!("Failed to stop the hosted network"));
-            }
-        }
-        Err(_) => return Err(format!("Failed to stop the hosted network through netsh")),
+        let ssid = "TestSSID";
+        let key = "TestKey";
+        let mut seq = Sequence::new();
+
+        mock_hotspotcommand
+            .expect_is_support_hotspot()
+            .times(1)
+            .returning(|| Ok(true))
+            .in_sequence(&mut seq);
+
+        mock_hotspotcommand
+            .expect_create_hotspot()
+            .with(eq(ssid), eq(key))
+            .times(1)
+            .returning(|_, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        mock_hotspotcommand
+            .expect_start_hotspot()
+            .times(1)
+            .returning(|| Ok(()))
+            .in_sequence(&mut seq);
+
+        create_ap_with_hotspotcommand(mock_hotspotcommand, ssid, key);
+    }
+    #[test]
+    fn test_create_ap_failure_when_unsupported() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
+        let ssid = "TestSSID";
+        let key = "TestKey";
+        let mut seq = Sequence::new();
+
+        mock_hotspotcommand
+            .expect_is_support_hotspot()
+            .times(1)
+            .returning(|| Ok(false))
+            .in_sequence(&mut seq);
+        mock_hotspotcommand.expect_create_hotspot().times(0);
+        mock_hotspotcommand.expect_start_hotspot().times(0);
+        create_ap_with_hotspotcommand(mock_hotspotcommand, ssid, key);
+    }
+    #[test]
+    fn test_create_ap_failure_when_create_hotspot_failed() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
+        let ssid = "TestSSID";
+        let key = "TestKey";
+        let mut seq = Sequence::new();
+
+        mock_hotspotcommand
+            .expect_is_support_hotspot()
+            .times(1)
+            .returning(|| Ok(true))
+            .in_sequence(&mut seq);
+        mock_hotspotcommand
+            .expect_create_hotspot()
+            .times(1)
+            .returning(|_, _| Err(format!("Failed")))
+            .in_sequence(&mut seq);
+        mock_hotspotcommand.expect_start_hotspot().times(0);
+        create_ap_with_hotspotcommand(mock_hotspotcommand, ssid, key);
+    }
+    #[test]
+    fn test_create_ap_failure_when_start_hotspot_failed() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
+        let ssid = "TestSSID";
+        let key = "TestKey";
+        let mut seq = Sequence::new();
+
+        mock_hotspotcommand
+            .expect_is_support_hotspot()
+            .times(1)
+            .returning(|| Ok(true))
+            .in_sequence(&mut seq);
+        mock_hotspotcommand
+            .expect_create_hotspot()
+            .times(1)
+            .returning(|_, _| Ok(()))
+            .in_sequence(&mut seq);
+        mock_hotspotcommand
+            .expect_start_hotspot()
+            .times(1)
+            .returning(|| Err(format!("Failed")))
+            .in_sequence(&mut seq);
+        create_ap_with_hotspotcommand(mock_hotspotcommand, ssid, key);
+    }
+
+    #[test]
+    fn test_turn_off_hotspot_success() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
+
+        mock_hotspotcommand
+            .expect_stop_hotspot()
+            .times(1)
+            .returning(|| Ok(()));
+
+        turn_off_hotspot_with_hotspotcommand(mock_hotspotcommand);
+    }
+    #[test]
+    fn test_turn_off_hotspot_failure_when_stop_hotspot_failed() {
+        let mut mock_hotspotcommand = MockHotSpotCommand::new();
+        mock_hotspotcommand
+            .expect_stop_hotspot()
+            .times(1)
+            .returning(|| Err(format!("Failed")));
+        turn_off_hotspot_with_hotspotcommand(mock_hotspotcommand);
     }
 }

--- a/core/src/net/windows_hotspot.rs
+++ b/core/src/net/windows_hotspot.rs
@@ -1,28 +1,129 @@
 use std::process::Command;
+fn command_output_to_string(output: &Vec<u8>) -> String {
+    let _output = std::str::from_utf8(&output);
+    match _output {
+        Ok(s) => s.to_string(),
+        Err(_) => "None".to_string(),
+    }
+}
+/// Create hotspot on windows
 #[allow(dead_code)]
 pub fn create_ap() {
+    // Check if the device support the hotspot feature
+    match is_support_hotspot() {
+        Ok(false) => {
+            println!("Hotspot is not supported");
+            return;
+        }
+        Err(e) => {
+            println!("{}", e);
+            return;
+        }
+        Ok(true) => println!("Hotspot is supported"),
+    };
     // Set up the hotspot name and password
     let hotspot_name = "MyHotspot";
     let hotspot_password = "MyPassword123";
 
-    // Execute the netsh commands to create the hotspot
-    let output = Command::new("netsh")
+    // Create a new hotspot
+    match create_hotspot(hotspot_name, hotspot_password) {
+        Ok(_) => println!("Created a new hotspot"),
+        Err(e) => {
+            println!("{}", e);
+            return;
+        }
+    };
+
+    // Start the hotspot
+    match start_hotspot() {
+        Ok(_) => println!("Started a new hotspot"),
+        Err(e) => {
+            println!("{}", e);
+            return;
+        }
+    };
+}
+
+#[warn(dead_code)]
+pub fn turn_off_hotspot() {
+    match stop_hotspot() {
+        Ok(_) => println!("Stop the hotspot successfully"),
+        Err(e) => println!("{}", e),
+    }
+}
+
+fn is_support_hotspot() -> Result<bool, String> {
+    match Command::new("netsh")
+        .args(["wlan", "show", "drivers"])
+        .output()
+    {
+        Ok(output) => {
+            if command_output_to_string(&output.stdout)
+                .as_str()
+                .contains("Hosted network supported  : Yes")
+            {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Err(_) => Err(format!("Failed to get the wlan drivers information")),
+    }
+}
+
+fn create_hotspot(ssid: &str, key: &str) -> Result<(), String> {
+    match Command::new("netsh")
         .args([
             "wlan",
             "set",
             "hostednetwork",
-            "mode=allow",
-            &("ssid=".to_owned() + hotspot_name),
-            &("key=".to_owned() + hotspot_password),
+            &("ssid=".to_owned() + ssid),
+            &("key=".to_owned() + key),
         ])
         .output()
-        .expect("Failed to execute 'netsh' command.");
+    {
+        Ok(output) => {
+            if let true = output.status.success() {
+                return Ok(());
+            } else {
+                return Err(format!(
+                    "Failed to create hotspot: {}",
+                    command_output_to_string(&output.stderr)
+                ));
+            }
+        }
+        Err(_) => return Err(format!("Failed to execute create hotspot through netsh.")),
+    }
+}
 
-    // Check the command execution result
-    if output.status.success() {
-        println!("Hotspot created successfully.");
-    } else {
-        let error_message = String::from_utf8_lossy(&output.stderr);
-        println!("Failed to create hotspot: {}", error_message);
+fn start_hotspot() -> Result<(), String> {
+    match Command::new("netsh")
+        .args(["wlan", "start", "hostednetwork"])
+        .output()
+    {
+        Ok(output) => {
+            if command_output_to_string(&output.stdout).contains("The hosted network started.") {
+                return Ok(());
+            } else {
+                return Err(format!("Failed to start the hosted network"));
+            }
+        }
+        Err(_) => return Err(format!("Failed to start the hosted network through netsh")),
+    }
+}
+
+fn stop_hotspot() -> Result<(), String> {
+    match Command::new("netsh")
+        .args(["wlan", "stop", "hostednetwork"])
+        .output()
+    {
+        Ok(output) => {
+            if command_output_to_string(&output.stdout).contains("The hosted network stoped.") {
+                return Ok(());
+            } else {
+                return Err(format!("Failed to stop the hosted network"));
+            }
+        }
+        Err(_) => return Err(format!("Failed to stop the hosted network through netsh")),
     }
 }


### PR DESCRIPTION
This commit adds functions for creating and managing a hotspot on Windows. The `create_ap` function checks if the device supports the hotspot feature and sets up the hotspot name and password. It then creates a new hotspot and starts it. The `turn_off_hotspot` function stops the hotspot.

The `is_support_hotspot` function uses the `netsh` command to check if the device supports the hosted network. The `create_hotspot` function uses the `netsh` command to create a new hotspot with the provided SSID and key. The `start_hotspot` function starts the created hotspot, and the `stop_hotspot` function stops the running hotspot.

These functions provide basic functionality for managing a hotspot on Windows.

Please review and test the code.